### PR TITLE
Add client-only dynamic StageView loader component

### DIFF
--- a/StageView.dynamic.tsx
+++ b/StageView.dynamic.tsx
@@ -1,0 +1,12 @@
+import dynamic from "next/dynamic";
+
+const StageView = dynamic(() => import("@/components/stage/StageView"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex-1 flex items-center justify-center">
+      Initializing 3D Engine...
+    </div>
+  ),
+});
+
+export default StageView;


### PR DESCRIPTION
### Motivation
- Prevent the 3D engine from initializing on the server and provide a user-friendly fallback while the client-only view loads.

### Description
- Add `StageView.dynamic.tsx` which uses `next/dynamic` to import `@/components/stage/StageView` with `ssr: false` and a centered loading fallback that displays `Initializing 3D Engine...`.

### Testing
- Ran `sed -n '1,120p' StageView.dynamic.tsx`, `nl -ba StageView.dynamic.tsx`, and `git status --short`, and each command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1da26f93483309e956d221ade52a4)