### PR TITLE
Agregar componente de audio con carátula

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ Diseñar una base conceptual y operativa para crear escenarios donde:
 - Prototipar una capa de datos geoespaciales mínima (POI, rutas, eventos).
 - Definir un piloto local con actores comunitarios.
 - Implementar un primer recorrido sensorial híbrido.
+
+## Componente de audio con carátula
+
+Se agregó un componente reutilizable para mostrar audio con imagen/carátula:
+
+- `components/audio/AudioWithCover.tsx`
+
+Ejemplo de uso:
+
+```tsx
+import AudioWithCover from "@/components/audio/AudioWithCover";
+
+<AudioWithCover
+  src="/audio/paisaje-sonoro.mp3"
+  coverImage="/images/paisaje-sonoro.jpg"
+  title="Paisaje Sonoro"
+  artist="Escenas Sensoriales"
+/>
+```

--- a/components/audio/AudioWithCover.tsx
+++ b/components/audio/AudioWithCover.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+type AudioWithCoverProps = {
+  src: string;
+  title?: string;
+  artist?: string;
+  coverImage: string;
+  alt?: string;
+};
+
+export default function AudioWithCover({
+  src,
+  title = "Audio",
+  artist,
+  coverImage,
+  alt,
+}: AudioWithCoverProps) {
+  return (
+    <figure className="max-w-sm rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm">
+      <img
+        src={coverImage}
+        alt={alt ?? `Carátula de ${title}`}
+        className="mb-3 aspect-square w-full rounded-xl object-cover"
+      />
+
+      <figcaption className="mb-3">
+        <p className="text-base font-semibold text-neutral-900">{title}</p>
+        {artist ? <p className="text-sm text-neutral-600">{artist}</p> : null}
+      </figcaption>
+
+      <audio controls preload="metadata" className="w-full" aria-label={`Reproductor de ${title}`}>
+        <source src={src} />
+        Tu navegador no soporta el elemento de audio.
+      </audio>
+    </figure>
+  );
+}


### PR DESCRIPTION
### Motivation
- Permitir asociar una imagen/carátula a un recurso de audio y mostrarlo junto con título y artista en la interfaz.
- Facilitar la inclusión de audios con metadatos visuales accesibles en las vistas del proyecto.

### Description
- Se agrega el componente reutilizable `components/audio/AudioWithCover.tsx` que recibe `src`, `coverImage`, `title`, `artist` y `alt` y renderiza una `img`, un `figcaption` y un reproductor `<audio>`.
- Se documenta el uso en `README.md` con un ejemplo listo para copiar que importa `AudioWithCover` y muestra `src` y `coverImage`.
- El componente incluye atributos de accesibilidad como `alt` para la imagen, `aria-label` en el reproductor y texto fallback para navegadores sin soporte de audio.

### Testing
- Se ejecutó `git diff --check` y no arrojó errores (success).
- Se buscó la referencia con `rg "AudioWithCover" -n README.md components/audio/AudioWithCover.tsx` para confirmar inclusión en la documentación y el componente, y encontró las apariciones esperadas (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a935f22ebc8330a2e81a5a0a3c22e4)